### PR TITLE
Update twitter version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val twitter = project
   .settings(
     libraryDependencies ++= Seq(
       "dev.zio"     %% "zio"          % "1.0.0-RC18",
-      "com.twitter" %% "util-core"    % "20.1.0",
+      "com.twitter" %% "util-core"    % "20.3.0",
       "dev.zio"     %% "zio-test"     % "1.0.0-RC18" % Test,
       "dev.zio"     %% "zio-test-sbt" % "1.0.0-RC18" % Test
     )


### PR DESCRIPTION
Twitter loves to build in hidden binary incompatibilities between point versions. Hence their use of CalVer

Upgrade twitter version to 20.3.0